### PR TITLE
Add title attribute to descriptor

### DIFF
--- a/spec/descriptor.json
+++ b/spec/descriptor.json
@@ -21,6 +21,9 @@
     "name": {
       "$ref": "definitions.json#/definitions/name"
     },
+    "title": {
+      "$ref": "definitions.json#/definitions/title"
+    },
     "type": {
       "$ref": "definitions.json#/definitions/type"
     },


### PR DESCRIPTION
In the spec, descriptor has title attribute.

https://github.com/alps-io/spec/blob/master/draft-07/draft-07.txt#L636