### PR TITLE
Add link element to descriptor

### DIFF
--- a/alps.xsd
+++ b/alps.xsd
@@ -125,6 +125,7 @@
         <xs:attribute name="rel" type="xs:string"/>
         <xs:attribute name="href" type="xs:anyURI"/>
         <xs:attribute name="tag" type="xs:string"/>
+        <xs:attribute name="title" type="xs:string"/>
         <xs:anyAttribute/>
     </xs:complexType>
     <xs:complexType name="docType">

--- a/alps.xsd
+++ b/alps.xsd
@@ -83,6 +83,7 @@
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element name="descriptor" type="descriptorType" minOccurs="0"/>
                 <xs:element name="doc" type="docType" minOccurs="0"/>
+                <xs:element name="link" type="linkType" minOccurs="0"/>
             </xs:choice>
         </xs:sequence>
         <!-- documented attribute -->

--- a/spec/definitions.json
+++ b/spec/definitions.json
@@ -118,8 +118,15 @@
                 },
                 "tag": {
                     "$ref": "definitions.json#/definitions/tag"
+                },
+                "title": {
+                    "$ref": "#/definitions/title"
                 }
-            }
+            },
+            "required": [
+                "rel",
+                "href"
+            ]
         },
         "link": {
             "oneOf": [

--- a/spec/descriptor.json
+++ b/spec/descriptor.json
@@ -39,6 +39,9 @@
     "tag": {
       "$ref": "definitions.json#/definitions/tag"
     },
+    "link": {
+      "$ref": "definitions.json#/definitions/link"
+    },
     "descriptor": {
       "type": "array",
       "items": {


### PR DESCRIPTION
- Add title attribute to link & required `href` & `rel` a0c06ce
  - https://datatracker.ietf.org/doc/html/draft-amundsen-richardson-foster-alps-07#section-2.2.10
  - >   The 'link' element MAY have 'title' and 'tag' attributes.
  - >   The 'link' element MUST define the two attributes 'href' and 'rel'.
- Add link element to descriptor 0dfc899
  -  https://datatracker.ietf.org/doc/html/draft-amundsen-richardson-foster-alps-07#section-2.2.10
  - >  MAY be a child element of the 'alps' and the 'descriptor' elements.